### PR TITLE
Fix: undefined method `any?' for nil:NilClass

### DIFF
--- a/manifests/object/checkcommand.pp
+++ b/manifests/object/checkcommand.pp
@@ -16,7 +16,7 @@ define icinga2::object::checkcommand (
   $command                               = undef,
   $cmd_path                              = 'PluginDir',
   $arguments                             = {},
-  $env                                   = undef,
+  $env                                   = {},
   $vars                                  = {},
   $timeout                               = undef,
   $target_dir                            = '/etc/icinga2/objects/checkcommands',
@@ -38,9 +38,9 @@ define icinga2::object::checkcommand (
     validate_string($template_to_import)
     validate_array($command)
     validate_string($cmd_path)
-    if $env {
-      validate_hash($env)
-    }
+    
+    validate_hash($env)
+      
     validate_hash($vars)
     if $timeout {
       validate_re($timeout, '^\d+$')


### PR DESCRIPTION
If you call icinga2::object::checkcommand without default parameter env, this error will be occurs.

env should be always an hash, otherwise mehtod any? is not avalible on the template.